### PR TITLE
Add timeout to wait for document dimensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ class SignaturePad extends Component {
         useFont: PropTypes.bool,
         name: PropTypes.string,
         fontStyle: PropTypes.string,
+        initTimeout: PropTypes.number
     };
 
     static defaultProps = {
@@ -56,7 +57,8 @@ class SignaturePad extends Component {
                 props.useFont,
                 escapedName,
                 props.height,
-                props.width
+                props.width,
+                props.initTimeout
             );
         var html = htmlContent(injectedJavaScript, props.fontStyle);
         this.source = {html};
@@ -84,7 +86,8 @@ class SignaturePad extends Component {
                     this.props.useFont,
                     escapedName,
                     this.props.height,
-                    this.props.width
+                    this.props.width,
+                    this.props.initTimeout
                 );
             var html = htmlContent(injectedJavaScript, this.props.fontStyle);
             this.source = {html};
@@ -183,6 +186,7 @@ class SignaturePad extends Component {
     render = () => {
         return (
             <WebView
+                ref={(ref) => { this._webview = ref }}
                 automaticallyAdjustContentInsets={false}
                 onNavigationStateChange={this._onNavigationChange}
                 onMessage={this._onMessage}

--- a/index.js
+++ b/index.js
@@ -183,6 +183,10 @@ class SignaturePad extends Component {
         }
     }
 
+    clear = () => {
+        this._webview.postMessage(JSON.stringify({ action: 'clear' }));
+    }
+
     render = () => {
         return (
             <WebView

--- a/index.js
+++ b/index.js
@@ -197,4 +197,4 @@ class SignaturePad extends Component {
     };
 }
 
-module.exports = SignaturePad;
+export { SignaturePad as default }

--- a/injectedHtml/index.js
+++ b/injectedHtml/index.js
@@ -25,7 +25,7 @@ var content = (script, fontStyle) =>
     </style>
 
     <style type="text/css">
-      ${fontStyle}
+      ${fontStyle || ''}
     </style>
 
     <body>

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -24,6 +24,25 @@ var showSignaturePad = function (signaturePadCanvas, bodyWidth, bodyHeight) {
     if ("${dataURL}") {
       signaturePad.fromDataURL("${dataURL}");
     }
+    document.addEventListener('message', function (event) {
+      var data;
+      try {
+        data = JSON.parse(event.data);
+      } catch (err) {
+        return;
+      }
+
+      if (!data) return;
+
+      var action = data['action'];
+      if (!action) return;
+
+      if (action === 'clear') {
+        signaturePad && signaturePad.clear();
+
+        return;
+      }
+    });
   };
 
   reportSize(width, height);


### PR DESCRIPTION
This is how I have managed to stop of SignaturePad from loading before the document has had time to set it's dimensions. Basically it polls every 100ms and waits for by default up 2 seconds, this can be configured in props.

This is a better fix then specifying explicit dimensions, it also does not interfere with that existing behaviour.

https://github.com/kevinstumpf/react-native-signature-pad/pull/18